### PR TITLE
chore: use newer pipx run syntax

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Build sdist and wheel
-      run: pipx run --spec build pyproject-build
+      run: pipx run build
 
     - uses: actions/upload-artifact@v2
       with:

--- a/{{cookiecutter.project_name}}/.github/workflows/wheels-pybind11.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/wheels-pybind11.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Build SDist
-      run: pipx run --spec build pyproject-build --sdist
+      run: pipx run build --sdist
 
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
https://github.com/pipxproject/pipx/pull/615 is now available in the latest GitHub Actions runners, so we can drop the old `--spec` portion.
