### PR TITLE
docs: convert recommonmark to myst-parser

### DIFF
--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -22,13 +22,15 @@ author = "{{ cookiecutter.full_name }}"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
+    "sphinx_copybutton",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ["_templates"]
+templates_path = []
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -41,7 +43,19 @@ exclude_patterns = ["_build", "**.ipynb_checkpoints", "Thumbs.db", ".DS_Store", 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_rtd_theme"
+html_theme = "sphinx_book_theme"
+
+html_title = f"Hist {version}"
+
+html_baseurl = "https://{{ cookiecutter.project_name.replace("-", "_") }}.readthedocs.io/en/latest/"
+
+html_theme_options = {
+    "home_page_in_toc": True,
+    "repository_url": "{{ cookiecutter.url }}",
+    "use_repository_button": True,
+    "use_issues_button": True,
+    "use_edit_page_button": True,
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/{{cookiecutter.project_name}}/pyproject-flit.toml
+++ b/{{cookiecutter.project_name}}/pyproject-flit.toml
@@ -37,10 +37,10 @@ dev = [
   "pytest >=4.6",
 ]
 docs = [
-  "recommonmark >=0.5.0",
   "Sphinx >=3.0.0",
+  "myst_parser>=0.13",
+  "sphinx-book-theme>=0.0.33",
   "sphinx_copybutton",
-  "sphinx_rtd_theme >=0.5.0",
 ]
 
 [build-system]

--- a/{{cookiecutter.project_name}}/pyproject-poetry.toml
+++ b/{{cookiecutter.project_name}}/pyproject-poetry.toml
@@ -36,10 +36,10 @@ dev = [
     "pytest >=4.6",
 ]
 docs = [
-  "recommonmark >=0.5.0",
   "Sphinx >=3.0.0",
+  "myst_parser>=0.13",
+  "sphinx-book-theme>=0.0.33",
   "sphinx_copybutton",
-  "sphinx_rtd_theme >=0.5.0",
 ]
 
 [build-system]

--- a/{{cookiecutter.project_name}}/setup.cfg
+++ b/{{cookiecutter.project_name}}/setup.cfg
@@ -50,9 +50,9 @@ dev =
     pytest>=4.6
 docs =
     Sphinx>=3.0.0
-    recommonmark>=0.5.0
+    myst_parser>=0.13
+    sphinx-book-theme>=0.0.33
     sphinx_copybutton
-    sphinx_rtd_theme>=0.5.0
 test =
     pytest>=4.6
 


### PR DESCRIPTION
Cleaning up the default, and switching to myst-parser. CC https://github.com/readthedocs/recommonmark/issues/221
