### PR TITLE
feat: use pyproject.toml more heavily

### DIFF
--- a/{{cookiecutter.project_name}}/.flake8
+++ b/{{cookiecutter.project_name}}/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+ignore = E203, E231, E501, E722, W503, B950
+select = C,E,F,W,T,B,B9,I
+per-file-ignores =
+    tests/*: T

--- a/{{cookiecutter.project_name}}/.github/workflows/ci-pybind11.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci-pybind11.yml
@@ -16,13 +16,14 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.2
+    - uses: pre-commit/action@v2.0.3
       with:
         extra_args: --hook-stage manual --all-files
 
   checks:
     name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
+    needs: [pre-commit]
     strategy:
       fail-fast: false
       matrix:

--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -19,13 +19,14 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.2
+    - uses: pre-commit/action@v2.0.3
       with:
         extra_args: --hook-stage manual --all-files
 
   checks:
     name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
+    needs: [pre-commit]
     strategy:
       fail-fast: false
       matrix:
@@ -54,6 +55,7 @@ jobs:
   dist:
     name: Distribution build
     runs-on: ubuntu-latest
+    needs: [pre-commit]
 
     steps:
     - uses: actions/checkout@v1

--- a/{{cookiecutter.project_name}}/.github/workflows/wheels-pybind11.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/wheels-pybind11.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         submodules: true
 
-    - uses: pypa/cibuildwheel@v1.11.0
+    - uses: pypa/cibuildwheel@v1.11.1
       env:
         CIBW_SKIP: cp27*
         CIBW_TEST_EXTRAS: test

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 20.8b1
+  rev: 21.5b2
   hooks:
   - id: black
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.4.0
+  rev: v4.0.1
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -24,7 +24,7 @@ repos:
   - id: isort
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.12.0
+  rev: v2.19.3
   hooks:
   - id: pyupgrade
     args: ["--py36-plus"]
@@ -39,14 +39,14 @@ repos:
 {%- endif %}
 
 - repo: https://github.com/pycqa/flake8
-  rev: 3.9.0
+  rev: 3.9.2
   hooks:
   - id: flake8
     exclude: docs/conf.py
     additional_dependencies: [flake8-bugbear, flake8-print]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.812
+  rev: v0.901
   hooks:
   - id: mypy
     files: src

--- a/{{cookiecutter.project_name}}/pyproject-flit.toml
+++ b/{{cookiecutter.project_name}}/pyproject-flit.toml
@@ -1,3 +1,8 @@
+[build-system]
+requires = ["flit_core >=2,<4"]
+build-backend = "flit_core.buildapi"
+
+
 [tool.flit.metadata]
 module = "{{ cookiecutter.project_name.replace("-", "_") }}"
 author = "{{ cookiecutter.full_name }}"
@@ -32,10 +37,10 @@ requires = [
 
 [tool.flit.metadata.requires-extra]
 test = [
-    "pytest >=4.6",
+    "pytest >=6",
 ]
 dev = [
-  "pytest >=4.6",
+  "pytest >=6",
 ]
 docs = [
   "Sphinx >=3.0.0",
@@ -44,12 +49,26 @@ docs = [
   "sphinx_copybutton",
 ]
 
-[build-system]
-requires = ["flit_core >=2,<4"]
-build-backend = "flit_core.buildapi"
-
-[tool.pytest.ini_config]
+[tool.pytest.ini_options]
 addopts = "-ra -Wd"
-testpaths = [
-    "tests",
-]
+testpaths = ["tests"]
+
+
+[tool.mypy]
+files = "src"
+python_version = "3.6"
+warn_unused_configs = true
+
+disallow_any_generics = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_return_any = true
+no_implicit_reexport = true
+strict_equality = true

--- a/{{cookiecutter.project_name}}/pyproject-poetry.toml
+++ b/{{cookiecutter.project_name}}/pyproject-poetry.toml
@@ -1,3 +1,8 @@
+[build-system]
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+
 [tool.poetry]
 name = "{{ cookiecutter.project_name.replace("-", "_") }}"
 version = "0.1.0"
@@ -42,12 +47,27 @@ docs = [
   "sphinx_copybutton",
 ]
 
-[build-system]
-requires = ["poetry_core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
 
-[tool.pytest.ini_config]
+[tool.pytest.ini_options]
 addopts = "-ra -Wd"
-testpaths = [
-    "tests",
-]
+testpaths = ["tests"]
+
+
+[tool.mypy]
+files = "src"
+python_version = "3.6"
+warn_unused_configs = true
+
+disallow_any_generics = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_return_any = true
+no_implicit_reexport = true
+strict_equality = true

--- a/{{cookiecutter.project_name}}/pyproject-pybind11.toml
+++ b/{{cookiecutter.project_name}}/pyproject-pybind11.toml
@@ -9,3 +9,38 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "src/{{ cookiecutter.project_name.replace("-", "_") }}/_version.py"
+
+
+[tool.pytest.ini_options]
+addopts = "-ra -Wd"
+testpaths = ["tests"]
+
+
+[tool.mypy]
+files = "src"
+python_version = "3.6"
+warn_unused_configs = true
+
+disallow_any_generics = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_return_any = true
+no_implicit_reexport = true
+strict_equality = true
+
+
+[tool.check-manifest]
+ignore = [
+    ".github/**",
+    "docs/**",
+    ".pre-commit-config.yaml",
+    ".readthedocs.yml",
+    "src/*/_version.py",
+]

--- a/{{cookiecutter.project_name}}/pyproject-setuptools.toml
+++ b/{{cookiecutter.project_name}}/pyproject-setuptools.toml
@@ -2,5 +2,41 @@
 requires = ["wheel", "setuptools>=42", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
+
 [tool.setuptools_scm]
 write_to = "src/{{ cookiecutter.project_name.replace("-", "_") }}/_version.py"
+
+
+[tool.pytest.ini_options]
+addopts = "-ra -Wd"
+testpaths = ["tests"]
+
+
+[tool.mypy]
+files = "src"
+python_version = "3.6"
+warn_unused_configs = true
+
+disallow_any_generics = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_return_any = true
+no_implicit_reexport = true
+strict_equality = true
+
+
+[tool.check-manifest]
+ignore = [
+    ".github/**",
+    "docs/**",
+    ".pre-commit-config.yaml",
+    ".readthedocs.yml",
+    "src/*/_version.py",
+]

--- a/{{cookiecutter.project_name}}/setup-setuptools,pybind11.cfg
+++ b/{{cookiecutter.project_name}}/setup-setuptools,pybind11.cfg
@@ -1,4 +1,3 @@
-{%- if cookiecutter.project_type == "setuptools" or cookiecutter.project_type == "pybind11" -%}
 [metadata]
 name = {{ cookiecutter.project_name.replace("-", "_") }}
 description = {{ cookiecutter.project_short_description }}
@@ -47,53 +46,17 @@ where = src
 
 [options.extras_require]
 dev =
-    pytest>=4.6
+    pytest>=6
 docs =
-    Sphinx>=3.0.0
+    Sphinx~=3.0
     myst_parser>=0.13
     sphinx-book-theme>=0.0.33
     sphinx_copybutton
 test =
-    pytest>=4.6
-
-[tool:pytest]
-addopts = -ra -Wd
-testpaths =
-    tests
-
-[check-manifest]
-ignore =
-    .github/**
-    docs/**
-    .pre-commit-config.yaml
-    .readthedocs.yml
-    src/*/_version.py
-
-{%- endif %}
+    pytest>=6
 
 [flake8]
 ignore = E203, E231, E501, E722, W503, B950
 select = C,E,F,W,T,B,B9,I
 per-file-ignores =
     tests/*: T
-
-[mypy]
-files = src
-python_version = 3.6
-warn_unused_configs = True
-disallow_any_generics = True
-disallow_subclassing_any = True
-disallow_untyped_calls = True
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-check_untyped_defs = True
-disallow_untyped_decorators = True
-no_implicit_optional = True
-warn_redundant_casts = True
-warn_unused_ignores = True
-warn_return_any = True
-no_implicit_reexport = True
-strict_equality = True
-
-[mypy-numpy]
-ignore_missing_imports = True

--- a/{{cookiecutter.project_name}}/setup-setuptools.py
+++ b/{{cookiecutter.project_name}}/setup-setuptools.py
@@ -7,3 +7,6 @@
 from setuptools import setup
 
 setup()
+
+# This file is optional, on recent versions of pip you can remove it and even
+# still get editable installs.


### PR DESCRIPTION
Using pyproject.toml more heavily, now that mypy supports it.

I might remove setup.py from the regular setuptools version, as it's no longer needed, and encourages bad practice, like `python setup.py <X>`.
