### PR TITLE
feat: dynamic versions for trampolim/flit621

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,10 @@ default_context:
   project_type: {backend}
 """
 
-ENV = {"SETUPTOOLS_SCM_PRETEND_VERSION": "0.1.0"}
+ENV = {
+    "SETUPTOOLS_SCM_PRETEND_VERSION": "0.1.0",
+    "TRAMPOLIM_VCS_VERSION": "0.1.0",
+}
 
 
 def make_cookie(session: nox.Session, backend: str) -> str:

--- a/{{cookiecutter.project_name}}/pyproject-flit621,trampolim.toml
+++ b/{{cookiecutter.project_name}}/pyproject-flit621,trampolim.toml
@@ -17,7 +17,6 @@ maintainers = [
 ]
 license = { file = "LICENSE" }
 
-version = "0.1.0"
 description = "{{ cookiecutter.project_short_description }}"
 readme = "README.md"
 
@@ -38,6 +37,8 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Development Status :: 1 - Planning",
 ]
+
+dynamic = ["version"]
 
 dependencies = [
   "numpy >=1.13.3",


### PR DESCRIPTION
Followup to #21, making the version dynamic (flit reads it from the file, trampolim gets it from VCS).
