### PR TITLE
feat: easier nox-powered update procedure for pre-commit

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -65,6 +65,17 @@ def lint(session: nox.Session, backend: str) -> None:
     )
 
 
+@nox.session
+@nox.parametrize("backend", BACKENDS, ids=BACKENDS)
+def autoupdate(session, backend):
+    session.install("cookiecutter", "pre-commit")
+
+    make_cookie(session, backend)
+
+    session.run("pre-commit", "autoupdate")
+    session.run("git", "diff", "--exit-code", external=True)
+
+
 @nox.session()
 @nox.parametrize("backend", BACKENDS, ids=BACKENDS)
 def tests(session, backend):

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 21.6b0
+  rev: 21.9b0
   hooks:
   - id: black
 
@@ -19,12 +19,12 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.9.2
+  rev: 5.9.3
   hooks:
   - id: isort
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.21.0
+  rev: v2.29.0
   hooks:
   - id: pyupgrade
     args: ["--py36-plus"]
@@ -71,7 +71,7 @@ repos:
 {%- if cookiecutter.project_type == "setuptools" or cookiecutter.project_type == "pybind11" %}
 
 - repo: https://github.com/mgedmin/check-manifest
-  rev: "0.46"
+  rev: "0.47"
   hooks:
   - id: check-manifest
     stages: [manual]


### PR DESCRIPTION
This prints out what needs to be updated when run (by hand) with `nox -s autoupdate`.
