### PR TITLE
feat: support Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
       run: nox --forcecolor -s 'tests(whey)'
 
     - name: Test poetry tooling
-      if: matrix.python-version != '3.10'
       run: nox --forcecolor -s tests_poetry
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
       run: nox --forcecolor -s 'tests(whey)'
 
     - name: Test poetry tooling
+      if: matrix.python-version != '3.10'
       run: nox --forcecolor -s tests_poetry
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: [3.6, "3.10"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
         include:

--- a/{{cookiecutter.project_name}}/.github/workflows/ci-pybind11.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci-pybind11.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: [3.6, "3.10"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
         include:

--- a/{{cookiecutter.project_name}}/.github/workflows/ci-trampolim.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci-trampolim.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: [3.6, "3.10"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
         include:

--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: [3.6, "3.10"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
         include:

--- a/{{cookiecutter.project_name}}/.github/workflows/wheels-pybind11.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/wheels-pybind11.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: pypa/cibuildwheel@v2.0.0
+    - uses: pypa/cibuildwheel@v2.1.2
 
     - name: Upload wheels
       uses: actions/upload-artifact@v2

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
 - repo: https://github.com/psf/black
   rev: 21.9b0
   hooks:
-  - id: black
+  - id: black-jupyter
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.0.1
@@ -32,7 +32,7 @@ repos:
 {%- if cookiecutter.project_type == "setuptools" or cookiecutter.project_type == "pybind11" %}
 
 - repo: https://github.com/asottile/setup-cfg-fmt
-  rev: v1.17.0
+  rev: v1.18.0
   hooks:
   - id: setup-cfg-fmt
 
@@ -41,7 +41,7 @@ repos:
 {%- if  cookiecutter.project_type == "pybind11" %}
 
 - repo: https://github.com/ssciwr/clang-format-hook
-  rev: v12.0.1
+  rev: v13.0.0
   hooks:
    - id: clang-format
 
@@ -61,7 +61,7 @@ repos:
     additional_dependencies: [flake8-bugbear, flake8-print]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.910
+  rev: v0.910-1
   hooks:
   - id: mypy
     {%- if cookiecutter.project_type == "trampolim" %}

--- a/{{cookiecutter.project_name}}/pyproject-flit.toml
+++ b/{{cookiecutter.project_name}}/pyproject-flit.toml
@@ -31,8 +31,7 @@ classifiers = [
 requires-python = ">=3.6"
 
 requires = [
-  "numpy >=1.13.3",
-  "typing; python_version<'3.5'",
+  "typing_extensions >=3.7; python_version<'3.8'",
 ]
 
 [tool.flit.metadata.requires-extra]

--- a/{{cookiecutter.project_name}}/pyproject-flit621,trampolim,whey.toml
+++ b/{{cookiecutter.project_name}}/pyproject-flit621,trampolim,whey.toml
@@ -55,8 +55,7 @@ dynamic = ["version"]
 {% endif -%}
 
 dependencies = [
-  "numpy >=1.13.3",
-  "typing; python_version<'3.5'",
+  "typing_extensions >=3.7; python_version<'3.8'",
 ]
 
 [project.optional-dependencies]

--- a/{{cookiecutter.project_name}}/pyproject-flit621,trampolim,whey.toml
+++ b/{{cookiecutter.project_name}}/pyproject-flit621,trampolim,whey.toml
@@ -1,6 +1,6 @@
 [build-system]
 {%- if cookiecutter.project_type == "trampolim" %}
-requires = ["trampolim >=0.0.3"]
+requires = ["trampolim ==0.0.3"]
 build-backend = "trampolim"
 {%- elif cookiecutter.project_type == "whey" %}
 requires = ["whey >=0.0.17"]

--- a/{{cookiecutter.project_name}}/pyproject-poetry.toml
+++ b/{{cookiecutter.project_name}}/pyproject-poetry.toml
@@ -28,7 +28,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.6"
-numpy = ">=1.13.3"
+typing_extensions = { version = ">=3.7", python = "<3.8" }
 
 pytest = { version = ">=6", optional = true }
 sphinx = { version = "^3.0", optional = true }

--- a/{{cookiecutter.project_name}}/setup-setuptools,pybind11.cfg
+++ b/{{cookiecutter.project_name}}/setup-setuptools,pybind11.cfg
@@ -25,6 +25,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering
 project_urls =
     Documentation = https://{{ cookiecutter.project_name.replace("-", "_") }}.readthedocs.io/

--- a/{{cookiecutter.project_name}}/setup-setuptools,pybind11.cfg
+++ b/{{cookiecutter.project_name}}/setup-setuptools,pybind11.cfg
@@ -36,7 +36,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    numpy>=1.13.3
+    typing_extensions>=3.7;python_version<'3.8'
 python_requires = >=3.6
 include_package_data = True
 package_dir =


### PR DESCRIPTION
Dropping numpy, as they are really slow getting out wheels sometimes. 3.10 Windows and macOS, for example. And musllinux.