### PR TITLE
fix: setuptools declares wheel/sdist dependencies already

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject-pybind11.toml
+++ b/{{cookiecutter.project_name}}/pyproject-pybind11.toml
@@ -1,9 +1,8 @@
 [build-system]
 requires = [
-    "wheel",
     "setuptools>=42",
     "setuptools_scm[toml]>=3.4",
-    "pybind11>=2.7.0",
+    "pybind11>=2.9.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/{{cookiecutter.project_name}}/pyproject-setuptools.toml
+++ b/{{cookiecutter.project_name}}/pyproject-setuptools.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["wheel", "setuptools>=42", "setuptools_scm[toml]>=3.4"]
+requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
Counterpart to https://github.com/scikit-hep/scikit-hep.github.io/pull/177
