### PR TITLE
[EXPERIMENT] Use setuptools auto-discovery for `src-layout`

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject^setuptools,pybind11,poetry.toml
+++ b/{{cookiecutter.project_name}}/pyproject^setuptools,pybind11,poetry.toml
@@ -29,12 +29,6 @@ source-dir = "src"
 {%- elif cookiecutter.project_type == "trampolim" %}
 [tool.trampolim]
 module-location = "src"
-{%- elif cookiecutter.project_type == "setuptools621" %}
-[tool.setuptools]
-# Bug in current impl. - this table must exist
-package-dir = {"" = "src"}
-[tool.setuptools.packages.find]
-where = ["src"]
 {%- endif %}
 
 

--- a/{{cookiecutter.project_name}}/pyproject^setuptools,pybind11,poetry.toml
+++ b/{{cookiecutter.project_name}}/pyproject^setuptools,pybind11,poetry.toml
@@ -15,7 +15,7 @@ build-backend = "maturin"
 requires = ["hatchling>=0.7"]
 build-backend = "hatchling.build"
 {%- elif cookiecutter.project_type == "setuptools621" %}
-requires = ["setuptools @ git+https://github.com/abravalheri/setuptools@support-pyproject", "wheel"]
+requires = ["setuptools @ git+https://github.com/pypa/setuptools@experimental/support-pyproject"]
 build-backend = "setuptools.build_meta"
 {%- else %}
 requires = ["flit_core >=3.4"]


### PR DESCRIPTION
Hi @henryiii, we previously discussed that it would be nice to have automatic discovery for the src-layout, and that was my original intention when implementing project metadata support (this way users have to write as little custom configuration as possible).

This PR is just an experiment to see how it would work on this project (on top of your previous experimental PR).

Currently [auto-discory](https://setuptools--2894.org.readthedocs.build/en/2894/userguide/package_discovery.html#automatic-discovery) works best with the src-layout. It will also work on flat-layout, however if the package has too many custom folders things might ended up added in the wheel.