### PR TITLE
feat: Add 'name-tests-test' to pre-commit hooks

### DIFF
--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: black-jupyter
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -15,6 +15,8 @@ repos:
       - id: debug-statements
       - id: end-of-file-fixer
       - id: mixed-line-ending
+      - id: name-tests-test
+        args: ["--pytest-test-first"]
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 


### PR DESCRIPTION
Motivated by https://github.com/scikit-hep/scikit-hep.github.io/issues/227 and complimentary to PR https://github.com/scikit-hep/scikit-hep.github.io/pull/231.

* Update pre-commit/pre-commit-hooks to v4.3.0
* Add the 'name-tests-test' pre-commit hooks which verifies that test files under `tests/` conform to `pytest` naming conventions.
   - Use the `--pytest-test-first` option to match the `test_.*\.py` naming convention.