### PR TITLE
chore: update versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/{{cookiecutter.project_name}}/.github/workflows/ci-pybind11.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci-pybind11.yml
@@ -17,8 +17,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v3
-      - uses: pre-commit/action@v2.0.3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - uses: pre-commit/action@v3.0.0
         with:
           extra_args: --hook-stage manual --all-files
       - name: Run PyLint
@@ -45,7 +47,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/{{cookiecutter.project_name}}/.github/workflows/ci-trampolim.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci-trampolim.yml
@@ -20,8 +20,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v3
-      - uses: pre-commit/action@v2.0.3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - uses: pre-commit/action@v3.0.0
         with:
           extra_args: --hook-stage manual --all-files
       - name: Run PyLint
@@ -48,7 +50,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -71,7 +73,7 @@ jobs:
       - name: Build sdist and wheel
         run: pipx run build
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist
 

--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -20,8 +20,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v3
-      - uses: pre-commit/action@v2.0.3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - uses: pre-commit/action@v3.0.0
         with:
           extra_args: --hook-stage manual --all-files
       - name: Run PyLint
@@ -48,7 +50,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/{{cookiecutter.project_name}}/.github/workflows/wheels-pybind11.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/wheels-pybind11.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pypa/cibuildwheel@v2.5.0
+      - uses: pypa/cibuildwheel@v2.7.0
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black-jupyter
 
@@ -32,7 +32,7 @@ repos:
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v2.6.2"
+    rev: "v2.7.1"
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
@@ -51,7 +51,7 @@ repos:
         args: ["-a", "from __future__ import annotations"] # Python 3.7+
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.0
+    rev: v2.34.0
     hooks:
       - id: pyupgrade
         args: ["--py37-plus"]
@@ -65,10 +65,10 @@ repos:
 
 {%- endif %}
 
-{%- if  cookiecutter.project_type == "pybind11" or cookiecutter.project_type == "skbuild" %}
+{%- if cookiecutter.project_type == "pybind11" or cookiecutter.project_type == "skbuild" %}
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v14.0.1
+    rev: v14.0.6
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]
@@ -76,7 +76,7 @@ repos:
 {%- endif %}
 
   - repo: https://github.com/hadialqattan/pycln
-    rev: v1.3.2
+    rev: v1.3.5
     hooks:
       - id: pycln
         additional_dependencies: [click<8.1]
@@ -100,7 +100,7 @@ repos:
         additional_dependencies: *flake8_dependencies
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.961
     hooks:
       - id: mypy
         files: src


### PR DESCRIPTION
Includes the setup-python v4 update, seehttps://github.com/actions/setup-python/issues/421.

- chore: bump GHA versions
- chore: bump pre-commit versions
