### PR TITLE
fix: remove include_package_data

### DIFF
--- a/{{cookiecutter.project_name}}/setup-skbuild.py
+++ b/{{cookiecutter.project_name}}/setup-skbuild.py
@@ -13,6 +13,5 @@ setup(
     name="{{ cookiecutter.project_name.replace("-","_") }}",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
-    include_package_data=True,
     cmake_install_dir="src/{{ cookiecutter.project_name.replace("-", "_") }}",
 )


### PR DESCRIPTION
Closes #98. For a first try, I'm thinking we don't actually need to include any package data, since CMakeLists.txt and stuff doesn't go in the wheel. But maybe I'm forgetting something.