### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -4,12 +4,12 @@ ci:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: "22.10.0"
     hooks:
       - id: black-jupyter
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: "v4.4.0"
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -25,7 +25,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: "v1.9.0"
     hooks:
       - id: python-check-blanket-noqa
       - id: python-check-blanket-type-ignore
@@ -43,19 +43,19 @@ repos:
         args: [--prose-wrap=always]
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.1
+    rev: "v1.12.1"
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==22.8.0]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: "5.10.1"
     hooks:
       - id: isort
         args: ["-a", "from __future__ import annotations"] # Python 3.7+
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.1.0
+    rev: "v3.3.0"
     hooks:
       - id: pyupgrade
         args: ["--py37-plus"]
@@ -63,7 +63,7 @@ repos:
 {%- if cookiecutter.project_type == "setuptools" or cookiecutter.project_type == "pybind11" or cookiecutter.project_type == "skbuild" %}
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.0.0
+    rev: "v2.2.0"
     hooks:
       - id: setup-cfg-fmt
         args: [--include-version-classifiers, --max-py-version=3.11]
@@ -74,7 +74,7 @@ repos:
 {%- if cookiecutter.project_type == "pybind11" or cookiecutter.project_type == "skbuild" %}
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v14.0.6
+    rev: "v14.0.6"
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]
@@ -82,7 +82,7 @@ repos:
 {%- endif %}
 
   - repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.1
+    rev: "v2.1.2"
     hooks:
       - id: pycln
         additional_dependencies: [click<8.1]
@@ -90,7 +90,7 @@ repos:
         stages: [manual]
 
   - repo: https://github.com/asottile/yesqa
-    rev: v1.4.0
+    rev: "v1.4.0"
     hooks:
       - id: yesqa
         exclude: docs/conf.py
@@ -99,14 +99,14 @@ repos:
           - flake8-print
 
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: "6.0.0"
     hooks:
       - id: flake8
         exclude: docs/conf.py
         additional_dependencies: *flake8_dependencies
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: "v0.991"
     hooks:
       - id: mypy
         files: src
@@ -118,7 +118,7 @@ repos:
       - id: codespell
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.8.0.4
+    rev: "v0.8.0.4"
     hooks:
       - id: shellcheck
 


### PR DESCRIPTION
Flake8 now requires Python 3.8+, hopefully won't break CI.
