### PR TITLE
ci: fix pass job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,11 @@ jobs:
           path: dist
           
   pass:
+    if: always()
     needs: [dist, nox, checks, pre-commit]
     runs-on: ubuntu-latest
     steps:
-      - run: echo "All jobs passed"
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Fixes the "pass on fail" feature of the previous implementation. This was not exposed in the cookiecutter, just in our own tests. Thanks to @webknjaz in https://github.com/pypa/build/pull/543 and https://github.com/mesonbuild/meson-python/pull/221#discussion_r1038060140.
