### PR TITLE
fix: poetry-core 1.5.0 broke isort

### DIFF
--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: "22.10.0"
+    rev: "22.12.0"
     hooks:
       - id: black-jupyter
 
@@ -25,7 +25,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: "v1.9.0"
+    rev: "v1.10.0"
     hooks:
       - id: python-check-blanket-noqa
       - id: python-check-blanket-type-ignore
@@ -43,19 +43,19 @@ repos:
         args: [--prose-wrap=always]
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: "v1.12.1"
+    rev: "1.13.0"
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==22.8.0]
 
   - repo: https://github.com/PyCQA/isort
-    rev: "5.10.1"
+    rev: "5.12.0"
     hooks:
       - id: isort
         args: ["-a", "from __future__ import annotations"] # Python 3.7+
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: "v3.3.0"
+    rev: "v3.3.1"
     hooks:
       - id: pyupgrade
         args: ["--py37-plus"]
@@ -82,7 +82,7 @@ repos:
 {%- endif %}
 
   - repo: https://github.com/hadialqattan/pycln
-    rev: "v2.1.2"
+    rev: "v2.1.3"
     hooks:
       - id: pycln
         additional_dependencies: [click<8.1]
@@ -118,7 +118,7 @@ repos:
       - id: codespell
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: "v0.8.0.4"
+    rev: "v0.9.0.2"
     hooks:
       - id: shellcheck
 
@@ -133,7 +133,7 @@ repos:
 {%- if cookiecutter.project_type == "setuptools" or cookiecutter.project_type == "pybind11" or cookiecutter.project_type == "skbuild"%}
 
   - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.48"
+    rev: "0.49"
     hooks:
       - id: check-manifest
         stages: [manual]

--- a/{{cookiecutter.project_name}}/CMakeLists-skbuild.txt
+++ b/{{cookiecutter.project_name}}/CMakeLists-skbuild.txt
@@ -7,7 +7,7 @@ FetchContent_Declare(
   pybind11
   URL https://github.com/pybind/pybind11/archive/refs/tags/v2.10.3.tar.gz
   URL_HASH
-    SHA256=4b80847061e918106250263c571067d514c735716bc6b4c2d2aadaf661c08c44)
+    SHA256=5d8c4c5dda428d3a944ba3d2a5212cb988c2fae4670d58075a5a49075a6ca315)
 FetchContent_MakeAvailable(pybind11)
 
 pybind11_add_module(_core MODULE src/main.cpp)

--- a/{{cookiecutter.project_name}}/CMakeLists-skbuild.txt
+++ b/{{cookiecutter.project_name}}/CMakeLists-skbuild.txt
@@ -5,9 +5,9 @@ include(FetchContent)
 
 FetchContent_Declare(
   pybind11
-  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.9.2.tar.gz
+  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.10.3.tar.gz
   URL_HASH
-    SHA256=6bd528c4dbe2276635dc787b6b1f2e5316cf6b49ee3e150264e455a0d68d19c1)
+    SHA256=4b80847061e918106250263c571067d514c735716bc6b4c2d2aadaf661c08c44)
 FetchContent_MakeAvailable(pybind11)
 
 pybind11_add_module(_core MODULE src/main.cpp)


### PR DESCRIPTION
See https://github.com/PyCQA/isort/pull/2078. Also GitHub [broke all hashes](https://github.blog/changelog/2023-01-30-git-archive-checksums-may-change/) for a few minutes, but it's back to normal. Might as well keep the pybind11 bump, though. 