### PR TITLE
fix: limit maturin

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "whey"
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"
 {%- elif cookiecutter.project_type == "maturin" %}
-requires = ["maturin>=0.12"]
+requires = ["maturin>=0.12,<0.15"]
 build-backend = "maturin"
 {%- elif cookiecutter.project_type == "hatch" %}
 requires = ["hatchling"]


### PR DESCRIPTION
The logic for lib names and sources changed, 0.15 broke us with https://github.com/PyO3/maturin/pull/1335 and https://github.com/PyO3/maturin/pull/1608 looks suspect too.
