### PR TITLE
Replace specific references to Scikit-HEP

### DIFF
--- a/docs/pages/developers/gha_basic.md
+++ b/docs/pages/developers/gha_basic.md
@@ -9,7 +9,7 @@ custom_title: GitHub Actions introduction
 
 {% include toc.html %}
 
-The recommended CI for Scikit-HEP is GitHub Actions (GHA), although its
+The recommended CI for scientific Python projects is GitHub Actions (GHA), although its
 predecessor Azure is also in heavy usage, and other popular services (Travis,
 Appveyor, and Circle CI) may be found in a few packages. GHA is preferred due
 to the flexible, extensible design and the tight integration with the GitHub

--- a/docs/pages/developers/gha_wheels.md
+++ b/docs/pages/developers/gha_wheels.md
@@ -11,10 +11,9 @@ custom_title: GitHub Actions for Binary Wheels
 
 Building binary wheels is a bit more involved, but can still be done
 effectively with GHA. This document will introduce [cibuildwheel][] for use in
-Scikit-HEP, replacing our in-house [azure-wheel-helpers][]. The benefits of
-cibuildwheel are a larger user base, fast fixes from CI and pip, works on all
-major CI vendors (no lock-in), and covers cases we were not able to cover (like
-ARM). We will focus on GHA below.
+your project. The benefits of cibuildwheel are a larger user base, fast fixes
+from CI and pip, works on all major CI vendors (no lock-in), and covers cases
+we were not able to cover (like ARM). We will focus on GHA below.
 
 ## Header
 
@@ -154,8 +153,7 @@ env:
   CIBW_MANYLINUX_I686_IMAGE: manylinux1
 ```
 
-You can even put any docker image here, including [Scikit-HEP's
-`skhep/manylinuxgcc-*`][manylinuxgcc] images with GCC 9. Note that
+You can even put any docker image here, as needed by the project. Note that
 manylinux1 was discontinued on Jan 1, 2022, and updates will cease whenever they
 break. If you always need a specific image, you can set that in the
 `pyproject.toml` file instead.
@@ -238,7 +236,6 @@ avoiding the sdist, for example).
 > to Travis CI's recent dramatic reduction on open source support, emulating
 > these architectures on GHA or Azure is probably better.
 
-[azure-wheel-helpers]: https://github.com/scikit-hep/azure-wheel-helpers
 [`cibw_before_build`]: https://cibuildwheel.readthedocs.io/en/stable/options/#before-build
 [`cibw_environment`]: https://cibuildwheel.readthedocs.io/en/stable/options/#environment
 [manylinuxgcc]: https://github.com/scikit-hep/manylinuxgcc

--- a/docs/pages/developers/gha_wheels.md
+++ b/docs/pages/developers/gha_wheels.md
@@ -238,7 +238,6 @@ avoiding the sdist, for example).
 
 [`cibw_before_build`]: https://cibuildwheel.readthedocs.io/en/stable/options/#before-build
 [`cibw_environment`]: https://cibuildwheel.readthedocs.io/en/stable/options/#environment
-[manylinuxgcc]: https://github.com/scikit-hep/manylinuxgcc
 [cibw custom]: https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip
 [cibuildwheel]: https://cibuildwheel.readthedocs.io/en/stable/
 [PyPI trusted publisher docs]: https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/

--- a/docs/pages/developers/index.md
+++ b/docs/pages/developers/index.md
@@ -26,11 +26,11 @@ Python][gha_pure], and one for [compiled extensions][gha_wheels]. You can read
 about setting up good tests on the [pytest page][pytest].
 
 Once you have completed the guidelines, there is a [cookiecutter][] project,
-[Scikit-HEP/cookie][], that implements these guidelines and lets you setup a
+[scientific-python/cookie][], that implements these guidelines and lets you setup a
 new package from a template in less than 60 seconds!
 
 You can also evaluate your repository against the guidelines by using
-[scikit-hep-repo-review][]!
+[scientific-python-repo-review][]!
 
 [intro]: {{ site.baseurl }}{% link pages/developers/intro.md %}
 [style]: {{ site.baseurl }}{% link pages/developers/style.md %}
@@ -41,7 +41,7 @@ You can also evaluate your repository against the guidelines by using
 [gha_pure]: {{ site.baseurl }}{% link pages/developers/gha_pure.md %}
 [gha_wheels]: {{ site.baseurl }}{% link pages/developers/gha_wheels.md %}
 [pytest]: {{ site.baseurl }}{% link pages/developers/pytest.md %}
-[scikit-hep-repo-review]: {{ site.baseurl }}{% link pages/developers/repo_review.md %}
+[scientific-python-repo-review]: {{ site.baseurl }}{% link pages/developers/repo_review.md %}
 
 [cookiecutter]: https://cookiecutter.readthedocs.io
-[scikit-hep/cookie]: https://github.com/scikit-hep/cookie
+[scientific-python/cookie]: https://github.com/scientific-python/cookie

--- a/docs/pages/developers/intro.md
+++ b/docs/pages/developers/intro.md
@@ -8,18 +8,17 @@ parent: Developer information
 
 {% include toc.html %}
 
-The libraries in Scikit-HEP try to follow best practices in the community
-for development and deployment (though some packages in Scikit-HEP are still
-being converted to use best practices). The following outlines the basics for setting
-up a development environment. It is recommended as a basis for `CONTRIBUTING.md` or
-`.github/CONTRIBUTING.md` in the packages.
+It is generally advisable for packages in the scientific Python ecosystem to try to
+follow best practices in the community for development and deployment. The following
+outlines the basics for setting up a development environment. It is recommended as a
+basis for `CONTRIBUTING.md` or `.github/CONTRIBUTING.md` in the packages.
 
 <details><summary>CONTRIBUTING.md template (click to expand)</summary>
 <pre>
-See the [Scikit-HEP Developer introduction][skhep-dev-intro] for a
-detailed description of best practices for developing Scikit-HEP packages.
+See the [Scientific Python Developer introduction][scientific-python-dev-intro] for a
+detailed description of best practices for developing Scientific Python packages.
 
-[skhep-dev-intro]: https://scikit-hep.org/developer/intro
+[scientific-python-dev-intro]: https://scientific-python.org/developer/intro
 
 # Setting up a development environment
 

--- a/docs/pages/developers/nox.md
+++ b/docs/pages/developers/nox.md
@@ -11,9 +11,9 @@ parent: Developer information
 A task runner, like [make][] (fully general), [rake][] (Ruby general),
 [invoke][] (Python general), [tox][] (Python packages), or [nox][] (Python
 simi-general), is a tool that lets you specify a set of tasks via a common
-interface. These have been discouraged in Scikit-HEP in the past, since they
-can be a crutch, allowing poor packaging practices to be employed behind a
-custom script, and they can hide what is actually happening.
+interface. These have been discouraged by some community projects in the past,
+since they can be a crutch, allowing poor packaging practices to be employed
+behind a custom script, and they can hide what is actually happening.
 
 We are carefully allowing an exception: [nox][]. Nox has two strong points that
 help with the above concerns. First, it is very explicit, and even prints what
@@ -160,7 +160,7 @@ will likely look similar across different projects:
 
 #### Lint
 
-All Scikit-HEP developers should be using pre-commit directly, but this helps new users.
+Ideally, all developers should be using pre-commit directly, but this helps new users.
 
 ```python
 @nox.session
@@ -244,7 +244,7 @@ def build(session: nox.Session) -> None:
 ### Examples
 
 A standard [powered by nox](https://github.com/scikit-hep/hist/blob/main/noxfile.py)
-package in Pure Python in Scikit-HEP is Hist.
+package in Pure Python can be found in the Hist project of Scikit-HEP.
 
 A package that happens to use PDM (like Poetry but better) is Scikit-HEP UHI,
 which is [powered by nox](https://github.com/scikit-hep/uhi/blob/main/noxfile.py).
@@ -252,7 +252,7 @@ Nox can setup a conda environment with ROOT (slow, but only nox and conda are
 required). There also is a version bump session, and does some custom logic
 too.
 
-The complex testing procedure powering Scikit-HEP Cookie is [powered by
+The complex testing procedure powering Scientific Python Cookie is [powered by
 nox](https://github.com/scikit-hep/cookie/blob/main/noxfile.py). It allows the
 complex CI jobs that generate projects and lint/test/build them to be run
 locally with no other setup.

--- a/docs/pages/developers/packaging.md
+++ b/docs/pages/developers/packaging.md
@@ -8,10 +8,10 @@ parent: Developer information
 
 {% include toc.html %}
 
-The libraries in Scikit-HEP have a variety of different packaging styles, but
-this document is intended to outline a recommended style that new packages
-should follow, and existing packages should slowly adopt. The reasoning for
-each decision is outlined as well.
+The libraries in the scientific Python ecosytem have a variety of different
+packaging styles, but this document is intended to outline a recommended style
+that new packages should follow, and existing packages should slowly adopt.
+The reasoning for each decision is outlined as well.
 
 There are currently several popular packaging systems. This guide covers
 [Setuptools][], which is currently the only system that supports compiled
@@ -78,27 +78,28 @@ you should have dev instructions on how to install requirements needed to run
 
 You can also use this to select your entire build system; we use setuptools
 above but you can also use others, such as [Flit][] or [Poetry][]. This is
-possible due to the `build-backend` selection, as described in PEP 517. No
-Scikit-HEP packages currently use these since they usually do not allow binary
-packages to be created and a few common developer needs, like editable
-installs, look slightly different (a way to include editable installs in PEP
-517 is being worked on). Usage of these "[hypermodern][]" packaging tools are
-generally not found in Scikit-HEP, but not discouraged; all tools build the
-same wheels (and they often build setuptools compliant SDists, as well).
+possible due to the `build-backend` selection, as described in PEP 517.
+Scientific Python packages don't often use these since they usually do not
+allow binary packages to be created and a few common developer needs, like
+editable installs, look slightly different (a way to include editable installs
+in PEP 517 is being worked on). Usage of these "[hypermodern][]" packaging
+tools are generally not found in scientific Python packages, but not
+discouraged; all tools build the same wheels (and they often build setuptools
+compliant SDists, as well).
 
 ### Special additions: NumPy
 
 You may want to build against NumPy (mostly for Cython packages, pybind11 does
 not need to access the NumPy headers). This is the recommendation for
-Scikit-HEP:
+scientific Python packages:
 
 ```toml
 requires = [
     "oldest-supported-numpy",
 ```
 
-This ensures the wheels built work with all versions of NumPy supported by
-Scikit-HEP. Whether you build the wheel locally or on CI, you can transfer it to
+This ensures the wheels built work with all versions of NumPy supported by your
+package. Whether you build the wheel locally or on CI, you can transfer it to
 someone else and it will work on any supported NumPy. The
 `oldest-supported-numpy` package is a SciPy metapackage from the NumPy
 developers that tracks the [correct version of NumPy to build wheels against for
@@ -109,7 +110,7 @@ for each Python version here.
 
 ## Versioning (medium/high priority)
 
-Packages in Scikit-HEP should use one of the following systems:
+Scientific Python packages should use one of the following systems:
 
 ### Git tags: official PyPA method
 
@@ -238,13 +239,6 @@ requirements only, this will fail.
 Flit will always look for `package.__version__`, and so will always import your
 package; you just have to deal with that if you use Flit.
 
-### pyhf Versioning system
-
-pyhf has a [custom version
-system](https://scikit-hep.org/pyhf/development.html#publishing) based on
-GitHub actions and bumpversion. At least one other package in Scikit-HEP is
-using this, as well.
-
 ## Setup configuration (medium priority)
 
 You should put as much as possible in your `setup.cfg`, and leave `setup.py`
@@ -259,11 +253,11 @@ name = package
 description = A great package.
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/scikit-hep/package
+url = https://github.com/organization/package
 author = My Name
 author_email = me@email.com
-maintainer = Scikit-HEP
-maintainer_email = scikit-hep-admins@googlegroups.com
+maintainer = My Organization
+maintainer_email = organization@email.com
 license = BSD-3-Clause
 license_file = LICENSE
 classifiers =
@@ -292,8 +286,8 @@ classifiers =
     Topic :: Utilities
 project_urls =
     Documentation = https://package.readthedocs.io/
-    Bug Tracker = https://github.com/scikit-hep/package/issues
-    Discussions = https://github.com/scikit-hep/package/discussions
+    Bug Tracker = https://github.com/organization/package/issues
+    Discussions = https://github.com/organization/package/discussions
     Changelog = https://package.readthedocs.io/en/latest/changelog.html
 
 
@@ -324,7 +318,7 @@ unless you are building extensions.
 # Copyright (c) 2020, My Name
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
-# or https://github.com/scikit-hep/package for details.
+# or https://github.com/organization/package for details.
 
 from setuptools import setup
 

--- a/docs/pages/developers/pep621.md
+++ b/docs/pages/developers/pep621.md
@@ -88,7 +88,7 @@ authors = [
   { name = "My Name", email = "me@email.com" },
 ]
 maintainers = [
-  { name = "Scikit-HEP", email = "scikit-hep-admins@googlegroups.com" },
+  { name = "My Organization", email = "myemail@email.com" },
 ]
 requires-python = ">=3.7"
 
@@ -109,10 +109,10 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/scikit-hep/package"
+Homepage = "https://github.com/organization/package"
 Documentation = "https://package.readthedocs.io/"
-"Bug Tracker" = "https://github.com/scikit-hep/package/issues"
-Discussions = "https://github.com/scikit-hep/package/discussions"
+"Bug Tracker" = "https://github.com/organization/package/issues"
+Discussions = "https://github.com/organization/package/discussions"
 Changelog = "https://package.readthedocs.io/en/latest/changelog.html"
 ```
 

--- a/docs/pages/developers/style.md
+++ b/docs/pages/developers/style.md
@@ -11,13 +11,15 @@ custom_title: Style guide
 
 ## Pre-commit
 
-Scikit-HEP uses [pre-commit][] to check code style. It can be installed through
-`brew` (macOS) or `pip` (anywhere). There are two modes to use it locally; you
-can check manually with `pre-commit run` (changes only) or `pre-commit run --all-files` (all). You can also run `pre-commit install` to add checks as a
-git pre-commit hook (which is where it gets its name). It's worth trying, even
-if you've tried and failed to set up a custom pre-commit hook before; it's quite
-elegant and does not add or commit the changes, it just makes the changes and
-allows you to check and add them. You can always override the hook with `-n`.
+Scientific Python projects often use [pre-commit][] to check code style. It
+can be installed through `brew` (macOS) or `pip` (anywhere). There are two
+modes to use it locally; you can check manually with `pre-commit run` (changes
+only) or `pre-commit run --all-files` (all). You can also run `pre-commit
+install` to add checks as a git pre-commit hook (which is where it gets its
+name). It's worth trying, even if you've tried and failed to set up a custom
+pre-commit hook before; it's quite elegant and does not add or commit the
+changes, it just makes the changes and allows you to check and add them. You
+can always override the hook with `-n`.
 
 [pre-commit]: https://pre-commit.com
 
@@ -56,8 +58,8 @@ update your `rev:` versions every week or so if your checks update!
 
 To use, just go to [pre-commit.ci](https://pre-commit.ci), click
 "Log in with GitHub", click "Add an Installation" if adding for the first time
-for an org or user, or "Manage repos on GitHub" for an existing installation
-(like Scikit-HEP), then add your repository from the list in GitHub's interface.
+for an org or user, or "Manage repos on GitHub" for an existing installation,
+then add your repository from the list in GitHub's interface.
 
 Now there will be a new check, and pre-commit.ci will commit changes if the
 pre-commit check made any changes. Note that there are a couple of missing features:
@@ -77,7 +79,7 @@ nested lists, matching brackets, etc. There also is a faction of developers
 that dislikes all auto-formatting tools, but inside a system like pre-commit,
 auto-formatters are ideal. They also speed up the writing of code because you
 can ignore formatting your code when you write it. By imposing a standard,
-all Scikit-HEP developers can quickly read any package's code.
+all scientific Python developers can quickly read any package's code.
 
 Also, properly formatted code has other benefits, such as if two developers
 make the same change, they get the same formatting, and merge requests are
@@ -415,14 +417,14 @@ when clearly better (please always use them, they are faster) if you set
 ## Type checking
 
 One of the most exciting advancements in Python in the last 10 years has been
-static type hints. Scikit-HEP is just beginning to make sure packages are
-type-hint ready. One of the challenges for providing static type hints is that
-it was developed in the Python 3 era and it really shines in a Python 3.7+
-codebase (due to `from __future__ import annotations`, which turns annotations
-into strings and allows you to use future Python features in Python 3.7+
-annotations as long as your type checker supports them). For now, it is
-recommended that you make an attempt to support type checking through your
-public API in the best way that you can (based on your supported Python
+static type hints. Scientific Python projects vary in the degree to which they
+are type-hint ready. One of the challenges for providing static type hints is
+that it was developed in the Python 3 era and it really shines in a
+Python 3.7+ codebase (due to `from __future__ import annotations`, which turns
+annotations into strings and allows you to use future Python features in
+Python 3.7+ annotations as long as your type checker supports them). For now,
+it is recommended that you make an attempt to support type checking through
+your public API in the best way that you can (based on your supported Python
 versions). Stub files can be used instead for out-of-line typing.
 [MyPy](https://mypy.readthedocs.io/en/stable/) is suggested for type checking,
 though there are several other good options to try, as well. If you have


### PR DESCRIPTION
Updating language to be less organization specific and apply to the general scientific Python community.

There are still a handful of remaining "hep" references:
- in `repo_review.md`
- in some code such as

```HTML
<div class="skhep-bar d-flex m-2" style="justify-content:center;">
  <button class="skhep-bar-item oidc-btn btn  m-2 btn-purple" onclick="openTab('oidc')">Trusted Publishing</button>
  <button class="skhep-bar-item token-btn btn m-2" onclick="openTab('token')">Token</button>
</div>

<div class="skhep-tab oidc-tab" markdown="1">
``` 