### PR TITLE
Skip build when the only changes were under docs/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      # Skip testing builds if changes are only in documentation directories
+      - 'docs/**'
   push:
     branches:
       - main


### PR DESCRIPTION
This uses [an approach borrowed from matplotlib](https://github.com/matplotlib/matplotlib/blob/main/.github/workflows/tests.yml).
In the future this could be revisited to use a [more sophisticated approach](https://github.com/pypa/build/blob/main/.github/workflows/reusable-change-detection.yml)
which marks the overall build as "passing" even though the non-applicable jobs were skipped.
