### PR TITLE
ci: fix readthedocs linking and css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,6 @@ _site/
 node_modules/
 package-lock.json
 package.json
+
+# readthedocs
+_readthedocs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,3 +14,4 @@ build:
     - cd docs && PATH="$HOME/.rvm/rubies/ruby-3.1.2/bin:$PATH" gem install bundler
     - cd docs && PATH="$HOME/.rvm/rubies/ruby-3.1.2/bin:$PATH" bundle install
     - cd docs && PATH="$HOME/.rvm/rubies/ruby-3.1.2/bin:$PATH" bundle exec jekyll build --destination ../_readthedocs/html
+    - env

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,5 +13,4 @@ build:
     - ~/.rvm/bin/rvm autolibs disable && ~/.rvm/bin/rvm install ruby 3.1.2
     - cd docs && PATH="$HOME/.rvm/rubies/ruby-3.1.2/bin:$PATH" gem install bundler
     - cd docs && PATH="$HOME/.rvm/rubies/ruby-3.1.2/bin:$PATH" bundle install
-    - cd docs && PATH="$HOME/.rvm/rubies/ruby-3.1.2/bin:$PATH" bundle exec jekyll build --destination ../_readthedocs/html
-    - env
+    - cd docs && PATH="$HOME/.rvm/rubies/ruby-3.1.2/bin:$PATH" bundle exec jekyll build --destination ../_readthedocs/html --baseurl $READTHEDOCS_CANONICAL_URL

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,4 +13,4 @@ build:
     - ~/.rvm/bin/rvm autolibs disable && ~/.rvm/bin/rvm install ruby 3.1.2
     - cd docs && PATH="$HOME/.rvm/rubies/ruby-3.1.2/bin:$PATH" gem install bundler
     - cd docs && PATH="$HOME/.rvm/rubies/ruby-3.1.2/bin:$PATH" bundle install
-    - cd docs && PATH="$HOME/.rvm/rubies/ruby-3.1.2/bin:$PATH" bundle exec jekyll build --destination ../_readthedocs/html --baseurl $(cut -d '/' -f 4- <<< "$READTHEDOCS_CANONICAL_URL")
+    - cd docs && PATH="$HOME/.rvm/rubies/ruby-3.1.2/bin:$PATH" bundle exec jekyll build --destination ../_readthedocs/html --baseurl $(echo -n "$READTHEDOCS_CANONICAL_URL" | cut -d '/' -f 4-)

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,4 +13,4 @@ build:
     - ~/.rvm/bin/rvm autolibs disable && ~/.rvm/bin/rvm install ruby 3.1.2
     - cd docs && PATH="$HOME/.rvm/rubies/ruby-3.1.2/bin:$PATH" gem install bundler
     - cd docs && PATH="$HOME/.rvm/rubies/ruby-3.1.2/bin:$PATH" bundle install
-    - cd docs && PATH="$HOME/.rvm/rubies/ruby-3.1.2/bin:$PATH" bundle exec jekyll build --destination ../_readthedocs/html --baseurl $READTHEDOCS_CANONICAL_URL
+    - cd docs && PATH="$HOME/.rvm/rubies/ruby-3.1.2/bin:$PATH" bundle exec jekyll build --destination ../_readthedocs/html --baseurl $(cut -d '/' -f 4- <<< "$READTHEDOCS_CANONICAL_URL")

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,8 +3,8 @@ email: scikit-hep-admins@googlegroups.com
 description: >-
   The Scikit-HEP Developer pages guide new users through the development
   process.
-baseurl: ""
-url: "https://scikit-hep.github.io/cookie"
+baseurl: ""  # Set by rtd
+url: "https://scikit-hep-cookie.readthedocs.io"
 github_username: scikit-hep
 
 # Build settings

--- a/docs/pages/guides/coverage.md
+++ b/docs/pages/guides/coverage.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Code coverage"
-permalink: /guides/coverage
+permalink: /guides/coverage/
 nav_order: 3
 parent: Topical Guides
 ---

--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "GHA: GitHub Actions intro"
-permalink: /guides/gha_basic
+permalink: /guides/gha_basic/
 nav_order: 10
 parent: Topical Guides
 custom_title: GitHub Actions introduction

--- a/docs/pages/guides/gha_pure.md
+++ b/docs/pages/guides/gha_pure.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "GHA: Pure Python wheels"
-permalink: /guides/gha_pure
+permalink: /guides/gha_pure/
 nav_order: 11
 parent: Topical Guides
 custom_title: GitHub Actions for pure Python wheels

--- a/docs/pages/guides/gha_wheels.md
+++ b/docs/pages/guides/gha_wheels.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "GHA: Binary wheels"
-permalink: /guides/gha_wheels
+permalink: /guides/gha_wheels/
 nav_order: 12
 parent: Topical Guides
 custom_title: GitHub Actions for Binary Wheels

--- a/docs/pages/guides/index.md
+++ b/docs/pages/guides/index.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Topical Guides
-permalink: /guides
+permalink: /guides/
 nav_order: 3
 has_children: true
 ---

--- a/docs/pages/guides/mypy.md
+++ b/docs/pages/guides/mypy.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Static type checking"
-permalink: /guides/mypy
+permalink: /guides/mypy/
 nav_order: 7
 parent: Topical Guides
 ---

--- a/docs/pages/guides/nox.md
+++ b/docs/pages/guides/nox.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Task runners
-permalink: /guides/tasks
+permalink: /guides/tasks/
 nav_order: 30
 parent: Topical Guides
 ---

--- a/docs/pages/guides/packaging.md
+++ b/docs/pages/guides/packaging.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Packaging
-permalink: /guides/packaging
+permalink: /guides/packaging/
 nav_order: 5
 parent: Topical Guides
 ---

--- a/docs/pages/guides/pep621.md
+++ b/docs/pages/guides/pep621.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Simple Python packaging
-permalink: /guides/pep621
+permalink: /guides/pep621/
 nav_order: 4
 parent: Topical Guides
 ---

--- a/docs/pages/guides/pytest.md
+++ b/docs/pages/guides/pytest.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Testing with pytest"
-permalink: /guides/pytest
+permalink: /guides/pytest/
 nav_order: 2
 parent: Topical Guides
 ---

--- a/docs/pages/guides/repo_review.md
+++ b/docs/pages/guides/repo_review.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Repo Review
-permalink: /guides/reporeview
+permalink: /guides/reporeview/
 nav_order: 110
 parent: Topical Guides
 interactive_repo_review: true

--- a/docs/pages/guides/style.md
+++ b/docs/pages/guides/style.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Style
-permalink: /guides/style
+permalink: /guides/style/
 nav_order: 6
 parent: Topical Guides
 custom_title: Style guide

--- a/docs/pages/patterns/index.md
+++ b/docs/pages/patterns/index.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Patterns
-permalink: /patterns
+permalink: /patterns/
 nav_order: 4
 has_children: true
 ---

--- a/docs/pages/principles/index.md
+++ b/docs/pages/principles/index.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Principles
-permalink: /principles
+permalink: /principles/
 nav_order: 2
 has_children: true
 ---

--- a/docs/pages/tutorials/dev-environment.md
+++ b/docs/pages/tutorials/dev-environment.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Intro to development
-permalink: /tutorials/dev-environment
+permalink: /tutorials/dev-environment/
 nav_order: 1
 parent: Tutorials
 ---

--- a/docs/pages/tutorials/index.md
+++ b/docs/pages/tutorials/index.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Tutorials
-permalink: /tutorials
+permalink: /tutorials/
 nav_order: 1
 has_children: true
 ---


### PR DESCRIPTION
Working on this. Example env:

```
READTHEDOCS_VIRTUALENV_PATH=/home/docs/checkouts/readthedocs.org/user_builds/scikit-hep-cookie/envs/142
READTHEDOCS_CANONICAL_URL=https://scikit-hep-cookie--142.org.readthedocs.build/en/142/
HOSTNAME=build-20808251-project-1003427-scikit-hep-cookie
READTHEDOCS_GIT_CLONE_URL=https://github.com/scikit-hep/cookie.git
HOME=/home/docs
NO_COLOR=1
READTHEDOCS=True
READTHEDOCS_PROJECT=scikit-hep-cookie
READTHEDOCS_OUTPUT=/home/docs/checkouts/readthedocs.org/user_builds/scikit-hep-cookie/checkouts/142/_readthedocs/
PATH=/home/docs/checkouts/readthedocs.org/user_builds/scikit-hep-cookie/envs/142/bin:/home/docs/.asdf/shims:/home/docs/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
READTHEDOCS_VERSION_TYPE=external
LANG=C.UTF-8
READTHEDOCS_LANGUAGE=en
DEBIAN_FRONTEND=noninteractive
READTHEDOCS_GIT_COMMIT_HASH=91076027ce9d8ee21e65e6efde6e89e413f46ebd
READTHEDOCS_VERSION_NAME=142
READTHEDOCS_VERSION=142
PWD=/home/docs/checkouts/readthedocs.org/user_builds/scikit-hep-cookie/checkouts/142
READTHEDOCS_GIT_IDENTIFIER=91076027ce9d8ee21e65e6efde6e89e413f46ebd
```
