### PR TITLE
Repo-review consistency.

### DIFF
--- a/docs/pages/guides/repo_review.md
+++ b/docs/pages/guides/repo_review.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Repo Review
-permalink: /guides/reporeview/
+permalink: /guides/repo-review/
 nav_order: 110
 parent: Topical Guides
 interactive_repo_review: true


### PR DESCRIPTION
Use dashes everywhere.

Closes #147

Unless maybe we want a CI action that check that "reporeview" is not present in the source/filenames of this repo.