### PR TITLE
Add guide on writing docs

### DIFF
--- a/docs/pages/guides/gha_basic.md
+++ b/docs/pages/guides/gha_basic.md
@@ -2,7 +2,7 @@
 layout: page
 title: "GHA: GitHub Actions intro"
 permalink: /guides/gha_basic/
-nav_order: 10
+nav_order: 11
 parent: Topical Guides
 custom_title: GitHub Actions introduction
 ---

--- a/docs/pages/guides/gha_pure.md
+++ b/docs/pages/guides/gha_pure.md
@@ -2,7 +2,7 @@
 layout: page
 title: "GHA: Pure Python wheels"
 permalink: /guides/gha_pure/
-nav_order: 11
+nav_order: 12
 parent: Topical Guides
 custom_title: GitHub Actions for pure Python wheels
 ---

--- a/docs/pages/guides/gha_wheels.md
+++ b/docs/pages/guides/gha_wheels.md
@@ -2,7 +2,7 @@
 layout: page
 title: "GHA: Binary wheels"
 permalink: /guides/gha_wheels/
-nav_order: 12
+nav_order: 13
 parent: Topical Guides
 custom_title: GitHub Actions for Binary Wheels
 ---

--- a/docs/pages/guides/mypy.md
+++ b/docs/pages/guides/mypy.md
@@ -2,7 +2,7 @@
 layout: page
 title: "Static type checking"
 permalink: /guides/mypy/
-nav_order: 7
+nav_order: 8
 parent: Topical Guides
 ---
 

--- a/docs/pages/guides/packaging_classic.md
+++ b/docs/pages/guides/packaging_classic.md
@@ -2,7 +2,7 @@
 layout: page
 title: Classic Packaging
 permalink: /guides/packaging_classic/
-nav_order: 5
+nav_order: 6
 parent: Topical Guides
 ---
 

--- a/docs/pages/guides/packaging_simple.md
+++ b/docs/pages/guides/packaging_simple.md
@@ -2,7 +2,7 @@
 layout: page
 title: Simple Packaging
 permalink: /guides/packaging-simple/
-nav_order: 4
+nav_order: 5
 parent: Topical Guides
 ---
 

--- a/docs/pages/guides/style.md
+++ b/docs/pages/guides/style.md
@@ -2,7 +2,7 @@
 layout: page
 title: Style
 permalink: /guides/style/
-nav_order: 6
+nav_order: 8
 parent: Topical Guides
 custom_title: Style guide
 ---

--- a/docs/pages/guides/writing-docs.md
+++ b/docs/pages/guides/writing-docs.md
@@ -215,9 +215,10 @@ Or you can generate a table that links out to documentation for each object.
 ```
 ````
 
+<!-- prettier-ignore-start -->
 [diátaxis]: https://diataxis.fr/
 [sphinx]: https://www.sphinx-doc.org/
 [myst]: https://myst-parser.readthedocs.io/
-[organizing content]:
-  https://myst-parser.readthedocs.io/en/latest/syntax/organising_content.html
+[organizing content]: https://myst-parser.readthedocs.io/en/latest/syntax/organising_content.html
 [sphinx-autodoc2]: https://sphinx-autodoc2.readthedocs.io/
+<!-- prettier-ignore-end -->

--- a/docs/pages/guides/writing-docs.md
+++ b/docs/pages/guides/writing-docs.md
@@ -92,14 +92,14 @@ example/
 (...)
 ```
 
-To build HTML from this source, install sphinx and the MyST Markdown parser.
+To build HTML from this source, install sphinx and the MyST Markdown parser
 
 ```bash
 pip install sphinx myst-parser
 ```
 
-and run `sphinx-build`, pointing it to your directory of source files and a
-target directory for writing rendered (HTML) output files.
+and then run `sphinx-build`, pointing it to your directory of source files and
+a target directory for writing rendered (HTML) output files.
 
 ```bash
 sphinx-build docs/ docs/build/
@@ -166,11 +166,11 @@ inputs and outputs of every public object in the codebase. This should not be
 written by hand; that would be tedious and have a high probably of human error
 or drifting out of sync over time.
 
-MyST recommends using [sphinx-autodoc2][]. However, we currently recommend using
-the built-in sphinx autodoc extension because it interoperates well with
-docstrings written to the numpydoc standard. Unfortunately, this requires a
-different syntax (rST) shown below. Fortunately, you can simply copy/paste these
-examples.
+MyST recommends using [sphinx-autodoc2][]. However, we currently recommend
+using the built-in sphinx `autodoc` and `autosummary` extensions because they
+interoperates well with docstrings written to the numpydoc standard. To invoke
+them, we need to employ yet another syntax (reST). F:ortunately, you can simply
+copy/paste these examples.
 
 Install `numpydoc`.
 

--- a/docs/pages/guides/writing-docs.md
+++ b/docs/pages/guides/writing-docs.md
@@ -1,0 +1,221 @@
+-We --
+layout: page
+title: Writing documentation
+permalink: /guides/writing-docs/
+nav_order: 30
+parent: Topical Guides
+---
+
+{% include toc.html %}
+
+# Writing Documentation
+
+## What to include
+
+Ideally, software documentation should include:
+
+* Introductory **tutorials**, to help new users (or potential users) understand
+  what the software can do and take their first steps
+* Task-oriented **guides**, examples that address specific uses
+* **Reference**, specifying the detailed inputs and outputs of every public object
+  in the codebase
+* **Explanations** to convey deeper understanding of why and how the software
+  operates the way it does
+
+This overall framework has a name, [Diátaxis][], and you can read more about it
+if you are interested.
+
+## Build the documentation
+
+Scientific Python software documentation can be written in the Markdown
+syntax, which looks like this:
+
+````markdown
+# My nifty title
+
+- list
+- of
+- items
+
+Some **bold** or *italicized* text!
+
+```python
+# A code block
+
+>>> 1 + 1
+2
+```
+````
+
+This documentation "source code" is then _built_ into a formats like HTML or
+PDF to be displayed to the user.
+
+There are a variety of tools that can do this. In this guide we will present an
+approach that is mainstream in the scientific Python community: the [Sphinx][]
+documentation generator with the [MyST][] plugin. Refer to the MyST
+documentation for more information on the Markdown syntax in general and MyST's
+flavor of Markdown in particular.
+
+We'll start with a very basic template. Start by create a `docs/` directory
+within your project (i.e. next to `src/`).
+
+```bash
+mkdir docs
+```
+
+In this directory, we will create a minimal Sphinx configuration file
+at `docs/conf.py`.
+
+```py
+# content of docs/conf.py
+
+project = "example"
+extensions = ["myst_parser"]
+```
+
+And, at `docs/index.md`, we will create a minimal front page for our
+documentation.
+
+```markdown
+# Example documentation
+
+Hello world!
+```
+
+You should now have something like this.
+
+```bash
+example/
+├── docs/
+│   ├── conf.py
+│   ├── index.md
+(...)
+```
+
+To build HTML from this source, install sphinx and the MyST Markdown parser.
+
+```bash
+pip install sphinx myst-parser
+```
+
+and run `sphinx-build`, pointing it to your directory of source files
+and a target directory for writing rendered (HTML) output files.
+
+```bash
+sphinx-build docs/ docs/build/
+```
+
+You should see some log message ending in `build succeeded.`
+This created the directory `docs/build`. Open `docs/build/index.html`
+in your web browser to view the documentation.
+
+## Essential Features of MyST Markdown
+
+We refer you to the [MyST][] documentation for topics including:
+
+* Typography
+* Tables
+* Images and figures
+* Cross-references
+* Math and equations
+* Including content from other files
+
+## Structure
+
+We began with this structure, having a single documentation page.
+
+```bash
+example/
+├── docs/
+│   ├── conf.py
+│   ├── index.md
+(...)
+```
+
+Suppose we add some tutorials pages in a subdirectory.
+
+```bash
+example/
+├── docs/
+│   ├── conf.py
+│   ├── index.md
+│   └── tutorials/
+│       ├── installation.md
+│       ├── first-steps.md
+│       └── real-application.md
+(...)
+```
+
+We can link them from the front page by using the MyST Markdown `{toctree}` directive.
+
+````markdown
+```{toctree}
+tutorials/installation.md
+tutorials/first-steps.md
+tutorials/real-application.md
+```
+````
+
+For more details see the MyST documentation page on [organizing content][].
+
+## Automatically generate reference documentation
+
+Reference documentation provides comprehensive documentation of the API:
+all the inputs and outputs of every public object in the codebase. This
+should not be written by hand; that would be tedious and have a high
+probably of human error or drifting out of sync over time.
+
+MyST recommends using [sphinx-autodoc2][]. However, we currently recommend
+using the built-in sphinx autodoc extension because it interoperates well with
+docstrings written to the numpydoc standard. Unfortunately, this requires a
+different syntax (rST) shown below. Fortunately, you can simply copy/paste
+these examples.
+
+Install `numpydoc`.
+
+```bash
+pip install numpydoc
+```
+
+In `docs/conf.py`, add to the list of extensions.
+
+```py
+extensions = [
+    # whatever you already have in here...
+
+    "numpydoc",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+]
+```
+
+(Note that `sphinx.ext.autodoc` and `sphinx.ext.autosummary` come
+installed with `sphinx`, so there is nothing more to install.)
+
+You can document a single object (e.g. function), shown inline on the page
+
+````markdown
+```{eval-rst}
+.. autofunction:: example.refraction.snell
+    :noindex:
+    :toctree: generated
+```
+````
+
+Or you can generate a table that links out to documentation for each object.
+
+````markdown
+```{eval-rst}
+.. autosummary::
+    :nosignatures:
+    :toctree: generated
+
+    example.refraction.snell
+```
+````
+
+[diátaxis]: https://diataxis.fr/
+[sphinx]: https://www.sphinx-doc.org/
+[myst]: https://myst-parser.readthedocs.io/
+[organizing content]: https://myst-parser.readthedocs.io/en/latest/syntax/organising_content.html
+[sphinx-autodoc2]: https://sphinx-autodoc2.readthedocs.io/

--- a/docs/pages/guides/writing-docs.md
+++ b/docs/pages/guides/writing-docs.md
@@ -1,8 +1,8 @@
--We --
+---
 layout: page
 title: Writing documentation
 permalink: /guides/writing-docs/
-nav_order: 30
+nav_order: 4
 parent: Topical Guides
 ---
 

--- a/docs/pages/guides/writing-docs.md
+++ b/docs/pages/guides/writing-docs.md
@@ -14,12 +14,12 @@ parent: Topical Guides
 
 Ideally, software documentation should include:
 
-* Introductory **tutorials**, to help new users (or potential users) understand
+- Introductory **tutorials**, to help new users (or potential users) understand
   what the software can do and take their first steps
-* Task-oriented **guides**, examples that address specific uses
-* **Reference**, specifying the detailed inputs and outputs of every public object
-  in the codebase
-* **Explanations** to convey deeper understanding of why and how the software
+- Task-oriented **guides**, examples that address specific uses
+- **Reference**, specifying the detailed inputs and outputs of every public
+  object in the codebase
+- **Explanations** to convey deeper understanding of why and how the software
   operates the way it does
 
 This overall framework has a name, [Diátaxis][], and you can read more about it
@@ -27,8 +27,8 @@ if you are interested.
 
 ## Build the documentation
 
-Scientific Python software documentation can be written in the Markdown
-syntax, which looks like this:
+Scientific Python software documentation can be written in the Markdown syntax,
+which looks like this:
 
 ````markdown
 # My nifty title
@@ -37,7 +37,7 @@ syntax, which looks like this:
 - of
 - items
 
-Some **bold** or *italicized* text!
+Some **bold** or _italicized_ text!
 
 ```python
 # A code block
@@ -47,8 +47,8 @@ Some **bold** or *italicized* text!
 ```
 ````
 
-This documentation "source code" is then _built_ into a formats like HTML or
-PDF to be displayed to the user.
+This documentation "source code" is then _built_ into a formats like HTML or PDF
+to be displayed to the user.
 
 There are a variety of tools that can do this. In this guide we will present an
 approach that is mainstream in the scientific Python community: the [Sphinx][]
@@ -63,8 +63,8 @@ within your project (i.e. next to `src/`).
 mkdir docs
 ```
 
-In this directory, we will create a minimal Sphinx configuration file
-at `docs/conf.py`.
+In this directory, we will create a minimal Sphinx configuration file at
+`docs/conf.py`.
 
 ```py
 # content of docs/conf.py
@@ -98,27 +98,27 @@ To build HTML from this source, install sphinx and the MyST Markdown parser.
 pip install sphinx myst-parser
 ```
 
-and run `sphinx-build`, pointing it to your directory of source files
-and a target directory for writing rendered (HTML) output files.
+and run `sphinx-build`, pointing it to your directory of source files and a
+target directory for writing rendered (HTML) output files.
 
 ```bash
 sphinx-build docs/ docs/build/
 ```
 
-You should see some log message ending in `build succeeded.`
-This created the directory `docs/build`. Open `docs/build/index.html`
-in your web browser to view the documentation.
+You should see some log message ending in `build succeeded.` This created the
+directory `docs/build`. Open `docs/build/index.html` in your web browser to view
+the documentation.
 
 ## Essential Features of MyST Markdown
 
 We refer you to the [MyST][] documentation for topics including:
 
-* Typography
-* Tables
-* Images and figures
-* Cross-references
-* Math and equations
-* Including content from other files
+- Typography
+- Tables
+- Images and figures
+- Cross-references
+- Math and equations
+- Including content from other files
 
 ## Structure
 
@@ -146,7 +146,8 @@ example/
 (...)
 ```
 
-We can link them from the front page by using the MyST Markdown `{toctree}` directive.
+We can link them from the front page by using the MyST Markdown `{toctree}`
+directive.
 
 ````markdown
 ```{toctree}
@@ -160,16 +161,16 @@ For more details see the MyST documentation page on [organizing content][].
 
 ## Automatically generate reference documentation
 
-Reference documentation provides comprehensive documentation of the API:
-all the inputs and outputs of every public object in the codebase. This
-should not be written by hand; that would be tedious and have a high
-probably of human error or drifting out of sync over time.
+Reference documentation provides comprehensive documentation of the API: all the
+inputs and outputs of every public object in the codebase. This should not be
+written by hand; that would be tedious and have a high probably of human error
+or drifting out of sync over time.
 
-MyST recommends using [sphinx-autodoc2][]. However, we currently recommend
-using the built-in sphinx autodoc extension because it interoperates well with
+MyST recommends using [sphinx-autodoc2][]. However, we currently recommend using
+the built-in sphinx autodoc extension because it interoperates well with
 docstrings written to the numpydoc standard. Unfortunately, this requires a
-different syntax (rST) shown below. Fortunately, you can simply copy/paste
-these examples.
+different syntax (rST) shown below. Fortunately, you can simply copy/paste these
+examples.
 
 Install `numpydoc`.
 
@@ -189,8 +190,8 @@ extensions = [
 ]
 ```
 
-(Note that `sphinx.ext.autodoc` and `sphinx.ext.autosummary` come
-installed with `sphinx`, so there is nothing more to install.)
+(Note that `sphinx.ext.autodoc` and `sphinx.ext.autosummary` come installed with
+`sphinx`, so there is nothing more to install.)
 
 You can document a single object (e.g. function), shown inline on the page
 
@@ -217,5 +218,6 @@ Or you can generate a table that links out to documentation for each object.
 [diátaxis]: https://diataxis.fr/
 [sphinx]: https://www.sphinx-doc.org/
 [myst]: https://myst-parser.readthedocs.io/
-[organizing content]: https://myst-parser.readthedocs.io/en/latest/syntax/organising_content.html
+[organizing content]:
+  https://myst-parser.readthedocs.io/en/latest/syntax/organising_content.html
 [sphinx-autodoc2]: https://sphinx-autodoc2.readthedocs.io/

--- a/docs/pages/guides/writing-docs.md
+++ b/docs/pages/guides/writing-docs.md
@@ -98,8 +98,8 @@ To build HTML from this source, install sphinx and the MyST Markdown parser
 pip install sphinx myst-parser
 ```
 
-and then run `sphinx-build`, pointing it to your directory of source files and
-a target directory for writing rendered (HTML) output files.
+and then run `sphinx-build`, pointing it to your directory of source files and a
+target directory for writing rendered (HTML) output files.
 
 ```bash
 sphinx-build docs/ docs/build/
@@ -166,8 +166,8 @@ inputs and outputs of every public object in the codebase. This should not be
 written by hand; that would be tedious and have a high probably of human error
 or drifting out of sync over time.
 
-MyST recommends using [sphinx-autodoc2][]. However, we currently recommend
-using the built-in sphinx `autodoc` and `autosummary` extensions because they
+MyST recommends using [sphinx-autodoc2][]. However, we currently recommend using
+the built-in sphinx `autodoc` and `autosummary` extensions because they
 interoperates well with docstrings written to the numpydoc standard. To invoke
 them, we need to employ yet another syntax (reST). F:ortunately, you can simply
 copy/paste these examples.

--- a/docs/pages/guides/writing-docs.md
+++ b/docs/pages/guides/writing-docs.md
@@ -42,8 +42,7 @@ Some **bold** or _italicized_ text!
 ```python
 # A code block
 
->>> 1 + 1
-2
+1 + 1
 ```
 ````
 


### PR DESCRIPTION
This is adapted from https://nsls-ii.github.io/scientific-python-cookiecutter/writing-docs.html.

We have intentionally omitted the sections on the IPython and Maplotlib (`.. plot:`) sphinx directives. Extension that execute code would probably be better addressed in a separate section, and we want to take some extra time to get familiar with current best practice. Best practice here seems to have evolved; it may be better to recommend Jupytext.